### PR TITLE
Fixed Visibility of Header's Content

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -34,7 +34,7 @@ function Header() {
   };
 
   return (
-    <header className="fixed w-full top-0 z-50  md:bg-opacity-0 md:backdrop-blur-sm hover:bg-opacity-60 transition duration-500 md:hover:bg-white  ">
+    <header className="fixed w-full top-0 z-50 bg-white md:bg-opacity-60 md:backdrop-blur-sm transition duration-500">
       <div className="relative mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between lg:h-20">
           <div className="flex-1 md:flex md:items-center md:gap-12">


### PR DESCRIPTION
Rather than changing the background to white on hover, we can keep the header's appearance consistent.

Solves: Issue #5 

https://github.com/user-attachments/assets/1836d658-0429-4fee-8ee5-c5b9750e63d4

